### PR TITLE
New video objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ git clone https://github.com/d3cod3/ofxPdExternals
 git clone https://github.com/d3cod3/ofxPDSP
 git clone https://github.com/d3cod3/ofxSyphon
 git clone https://github.com/d3cod3/ofxTimeline
+git clone --branch=main https://github.com/armadillu/ofxTurboJpeg
 git clone https://github.com/d3cod3/ofxWarp
 git clone https://github.com/d3cod3/ofxVisualProgramming
 ```
@@ -353,8 +354,10 @@ Texture | Ready
 image exporter | X |
 image loader | X |
 kinect grabber | X |
+lossy JPEG compression | - |
 pixels to texture | X |
 texture crop | X |
+texture information | - |
 texture mixer | X |
 texture to pixels | X |
 texture transform | X |
@@ -420,3 +423,5 @@ ofxSyphon original addon by [Anthony Stellato](https://github.com/astellato)
 ofxTimeline original addon by [James George and YCAM Interlab](https://github.com/YCAMInterlab/ofxTimeline)
 
 ofxWarp original addon by [Elie Zananiri](https://github.com/prisonerjohn/ofxWarp)
+
+ofxTurboJpeg addon by [Oriol Ferrer Mesia](https://github.com/armadillu/ofxTurboJpeg)

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -28,7 +28,7 @@ common:
         ADDON_DEPENDENCIES += ofxAudioAnalyzer ofxAudioFile ofxBTrack ofxChromaKeyShader ofxCv ofxEasing ofxFFmpegRecorder
         ADDON_DEPENDENCIES += ofxJSON ofxInfiniteCanvas ofxLua ofxMidi ofxMtlMapping2D
         ADDON_DEPENDENCIES += ofxPDSP ofxTimeline ofxWarp
-        ADDON_DEPENDENCIES += ofxImGui
+        ADDON_DEPENDENCIES += ofxImGui ofxTurboJpeg
 
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be

--- a/src/objects/video/TextureInformation.cpp
+++ b/src/objects/video/TextureInformation.cpp
@@ -1,0 +1,176 @@
+/*==============================================================================
+
+    ofxVisualProgramming: A visual programming patching environment for OF
+
+    Copyright (c) 2022 Daan de Lange
+
+    ofxVisualProgramming is distributed under the MIT License.
+    This gives everyone the freedoms to use ofxVisualProgramming in any context:
+    commercial or non-commercial, public or private, open or closed source.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    See https://github.com/d3cod3/ofxVisualProgramming for documentation
+
+==============================================================================*/
+
+#ifndef OFXVP_BUILD_WITH_MINIMAL_OBJECTS
+
+#include "TextureInformation.h"
+
+//--------------------------------------------------------------
+TextureInformation::TextureInformation() : PatchObject("texture information"){
+
+    this->numInlets  = 1;
+    this->numOutlets = 6;
+
+    this->texWidth = this->texHeight = this->texChannels = this->texID = this->texBytesPerChannel = 0.f;
+
+    _inletParams[0] = nullptr;//new ofTexture();  // texture
+//    _outletParams[0] = &this->texWidth; //new float();  // texture
+//    _outletParams[1] = &this->texHeight;
+//    _outletParams[2] = &this->texIsAllocated;
+//    _outletParams[3] = &this->texID;
+//    _outletParams[4] = &this->texChannels;
+//    _outletParams[5] = &this->texBytesPerChannel;
+    // Here they have to be new, otherwise it won't work... weird !
+    _outletParams[0] = new float();
+    _outletParams[1] = new float();
+    _outletParams[2] = new float();
+    _outletParams[3] = new float();
+    _outletParams[4] = new float();
+    _outletParams[5] = new float();
+
+    this->initInletsState();
+
+    loaded                  = false;
+
+}
+
+//--------------------------------------------------------------
+void TextureInformation::newObject(){
+    PatchObject::setName( this->objectName );
+
+    this->addInlet(VP_LINK_TEXTURE,"texture");
+    this->addOutlet(VP_LINK_NUMERIC,"width");
+    this->addOutlet(VP_LINK_NUMERIC,"height");
+    this->addOutlet(VP_LINK_NUMERIC,"allocated");
+    this->addOutlet(VP_LINK_NUMERIC,"texID");
+    this->addOutlet(VP_LINK_NUMERIC,"channels");
+    this->addOutlet(VP_LINK_NUMERIC,"channel bytes");
+
+}
+
+//--------------------------------------------------------------
+void TextureInformation::setupObjectContent(shared_ptr<ofAppGLFWWindow> &mainWindow){
+    this->loaded = true;
+}
+
+//--------------------------------------------------------------
+void TextureInformation::updateObjectContent(map<int,shared_ptr<PatchObject>> &patchObjects){
+    if( this->inletsConnected[0] ){
+        ofTexture* inTex = static_cast< ofTexture* >(_inletParams[0]);
+        if( inTex && inTex->isAllocated() ){
+            this->texIsAllocated = true;
+            this->texWidth = inTex->getWidth();
+            this->texHeight = inTex->getHeight();
+            this->texID = inTex->getTextureData().textureID;
+            this->texChannels = ofGetNumChannelsFromGLFormat(ofGetGLFormatFromInternal(inTex->getTextureData().glInternalFormat));
+            this->texBytesPerChannel = ofGetBytesPerChannelFromGLType(ofGetGLTypeFromInternal(inTex->getTextureData().glInternalFormat));
+        }
+        else this->texIsAllocated = false;
+    }
+    else this->texIsAllocated = false;
+
+    // Ensure to reset values on unallocated textures
+    if( !this->texIsAllocated ){
+        this->texWidth = this->texHeight = this->texChannels = this->texID = this->texBytesPerChannel = 0.f;
+    }
+
+    // Sync pointers with pointers : dirty code is dirty
+    *(float *)&_outletParams[0] = this->texWidth;
+    *(float *)&_outletParams[1] = this->texHeight;
+    *(float *)&_outletParams[2] = this->texIsAllocated;
+    *(float *)&_outletParams[3] = this->texID;
+    *(float *)&_outletParams[4] = this->texChannels;
+    *(float *)&_outletParams[5] = this->texBytesPerChannel;
+//    _outletParams[1] = &this->texHeight;
+//    _outletParams[2] = &this->texIsAllocated;
+//    _outletParams[3] = &this->texID;
+//    _outletParams[4] = &this->texChannels;
+//    _outletParams[5] = &this->texBytesPerChannel;
+}
+
+//--------------------------------------------------------------
+void TextureInformation::drawObjectContent(ofTrueTypeFont *font, shared_ptr<ofBaseGLRenderer>& glRenderer){
+
+}
+
+//--------------------------------------------------------------
+void TextureInformation::drawObjectNodeGui( ImGuiEx::NodeCanvas& _nodeCanvas ){
+
+    // CONFIG GUI inside Menu
+    if(_nodeCanvas.BeginNodeMenu()){
+        ImGui::Separator();
+        ImGui::Separator();
+        ImGui::Separator();
+
+        if (ImGui::BeginMenu("CONFIG"))
+        {
+
+            drawObjectNodeConfig(); this->configMenuWidth = ImGui::GetWindowWidth();
+
+            ImGui::EndMenu();
+        }
+        _nodeCanvas.EndNodeMenu();
+    }
+
+    // Visualize (Object main view)
+    if( _nodeCanvas.BeginNodeContent(ImGuiExNodeView_Visualise) ){
+
+        ImGui::Dummy(ImVec2(10,10));
+
+        ImGui::TextDisabled( "Size: %.0fx%.0f", this->texWidth, this->texHeight );
+        ImGui::TextDisabled( "Allocated: %d", (this->texIsAllocated == 1.f)?1:0 );
+        ImGui::TextDisabled( "TextureID: %.0f", this->texID );
+        ImGui::TextDisabled( "Color channels: %.0f", this->texChannels );
+        ImGui::TextDisabled( "Bytes per channel: %.0f", this->texBytesPerChannel );
+
+        _nodeCanvas.EndNodeContent();
+    }
+
+
+
+}
+
+//--------------------------------------------------------------
+void TextureInformation::drawObjectNodeConfig(){
+    ImGuiEx::ObjectInfo(
+                "Extracts some texture information.",
+                "https://mosaic.d3cod3.org/reference.php?r=texture-information");
+}
+
+//--------------------------------------------------------------
+void TextureInformation::removeObjectContent(bool removeFileFromData){
+    
+}
+
+OBJECT_REGISTER( TextureInformation, "texture information", OFXVP_OBJECT_CAT_TEXTURE)
+
+#endif

--- a/src/objects/video/TextureInformation.h
+++ b/src/objects/video/TextureInformation.h
@@ -1,0 +1,68 @@
+/*==============================================================================
+
+    ofxVisualProgramming: A visual programming patching environment for OF
+
+    Copyright (c) 2022 Daan de Lange
+
+    ofxVisualProgramming is distributed under the MIT License.
+    This gives everyone the freedoms to use ofxVisualProgramming in any context:
+    commercial or non-commercial, public or private, open or closed source.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    See https://github.com/d3cod3/ofxVisualProgramming for documentation
+
+==============================================================================*/
+
+// This Object extracts texture information (dimensions, channel info, allocation info) from a connected.
+
+
+#ifndef OFXVP_BUILD_WITH_MINIMAL_OBJECTS
+
+#pragma once
+
+#include "PatchObject.h"
+
+class TextureInformation : public PatchObject {
+
+public:
+
+    TextureInformation();
+
+    void            newObject() override;
+    void            setupObjectContent(shared_ptr<ofAppGLFWWindow> &mainWindow) override;
+    void            updateObjectContent(map<int,shared_ptr<PatchObject>> &patchObjects) override;
+
+    void            drawObjectContent(ofTrueTypeFont *font, shared_ptr<ofBaseGLRenderer>& glRenderer) override;
+    void            drawObjectNodeGui( ImGuiEx::NodeCanvas& _nodeCanvas ) override;
+    void            drawObjectNodeConfig() override;
+
+    void            removeObjectContent(bool removeFileFromData=false) override;
+
+    float texWidth, texHeight, texChannels, texIsAllocated, texID, texBytesPerChannel;
+
+    bool            loaded;
+
+private:
+
+    OBJECT_FACTORY_PROPS
+
+};
+
+#endif

--- a/src/objects/video/VideoGrabber.cpp
+++ b/src/objects/video/VideoGrabber.cpp
@@ -232,7 +232,7 @@ void VideoGrabber::drawObjectNodeConfig(){
     ImGui::Text("Format: %ix%i",camWidth,camHeight);
 
     ImGui::Spacing();
-    if(ImGui::BeginCombo("Device", devicesVector.at(deviceID).c_str() )){
+    if(ImGui::BeginCombo("Device", devicesVector.size()>deviceID ? devicesVector.at(deviceID).c_str() : deviceName.c_str() )){
         for(int i=0; i < devicesVector.size(); ++i){
             bool is_selected = (deviceID == i );
             if (ImGui::Selectable(devicesVector.at(i).c_str(), is_selected)){

--- a/src/objects/video/lossyJPEGCompression.cpp
+++ b/src/objects/video/lossyJPEGCompression.cpp
@@ -1,0 +1,301 @@
+/*==============================================================================
+
+    ofxVisualProgramming: A visual programming patching environment for OF
+
+    Copyright (c) 2022 Daan de Lange
+
+    ofxVisualProgramming is distributed under the MIT License.
+    This gives everyone the freedoms to use ofxVisualProgramming in any context:
+    commercial or non-commercial, public or private, open or closed source.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    See https://github.com/d3cod3/ofxVisualProgramming for documentation
+
+==============================================================================*/
+
+#ifndef OFXVP_BUILD_WITH_MINIMAL_OBJECTS
+
+#include "lossyJPEGCompression.h"
+
+//--------------------------------------------------------------
+lossyJPEGCompression::lossyJPEGCompression() : PatchObject("lossy JPEG compression"){
+
+    this->numInlets  = 2;
+    this->numOutlets = 1;
+
+    _inletParams[0] = new ofPixels();  // input
+    _inletParams[1] = new float();  // input
+    *(float *)&_inletParams[1] = 0.0f;
+    _outletParams[0] = new ofPixels(); // output
+
+    this->initInletsState();
+
+    this->bInitialised = false;
+    this->bIsThreaded = false;
+    this->fJpegQuality = 80.f;
+
+    handleCompress = tjInitCompress();
+    if (handleCompress == NULL){
+        printf("Error in tjInitCompress():\n%s\n", tjGetErrorStr());
+    }
+
+    handleDecompress = tjInitDecompress();
+    if (handleDecompress == NULL){
+        printf("Error in tjInitDeCompress():\n%s\n", tjGetErrorStr());
+    }
+
+
+}
+
+//--------------------------------------------------------------
+void lossyJPEGCompression::newObject(){
+    PatchObject::setName( this->objectName );
+
+    this->addInlet(VP_LINK_PIXELS,"pixelsToCompress");
+    this->addInlet(VP_LINK_NUMERIC,"jpegQuality");
+
+    this->addOutlet(VP_LINK_PIXELS,"compressedPixels");
+
+}
+
+//--------------------------------------------------------------
+void lossyJPEGCompression::setupObjectContent(shared_ptr<ofAppGLFWWindow> &mainWindow){
+    this->fJpegQuality = this->getCustomVar("JPEG-quality");
+}
+
+//--------------------------------------------------------------
+void lossyJPEGCompression::updateObjectContent(map<int,shared_ptr<PatchObject>> &patchObjects){
+
+    // UPDATE STUFF
+    // Read quality from inlet
+    if( this->inletsConnected[1] ){
+        //float inQuality = *(float *)&_inletParams[1];
+        //float inQuality = *static_cast<float*>(_inletParams[1]);
+        float inQuality = *reinterpret_cast<float*>(&(_inletParams[1]));
+        // Valid image ?
+        if(inQuality){
+            this->fJpegQuality = inQuality;
+        }
+    }
+
+    // Read pixels from inlet [or should this be done in drawObjectContent() ?]
+    // Connected ?
+    if( this->inletsConnected[0] ){
+        ofPixels* pixels = static_cast<ofPixels *>(_inletParams[0]);
+        // Valid image ?
+        if( pixels && pixels->isAllocated() ){
+            outPixels = *pixels; // Duplication needed not to edit the connected original
+            threadablePixelsFunction(outPixels); // Note: if this fails, a copy of the original pixels object is passed to ensure the pixels remain available and valid. (Is this the desired behaviour ?)
+            _outletParams[0] = &outPixels;
+//            threadablePixelsFunction(*pixels);
+//            _outletParams[0] = pixels;
+        }
+        //else std::cout << "No valid pixels ! :o" << std::endl;
+    }
+}
+
+//--------------------------------------------------------------
+void lossyJPEGCompression::drawObjectContent(ofTrueTypeFont *font, shared_ptr<ofBaseGLRenderer>& glRenderer){
+
+}
+
+//--------------------------------------------------------------
+void lossyJPEGCompression::drawObjectNodeGui( ImGuiEx::NodeCanvas& _nodeCanvas ){
+
+    // CONFIG GUI inside Menu
+    if(_nodeCanvas.BeginNodeMenu()){
+
+        ImGui::Separator();
+        ImGui::Separator();
+        ImGui::Separator();
+
+        if (ImGui::BeginMenu("CONFIG"))
+        {
+
+            drawObjectNodeConfig(); this->configMenuWidth = ImGui::GetWindowWidth();
+
+            ImGui::EndMenu();
+        }
+
+        _nodeCanvas.EndNodeMenu();
+    }
+
+    // Visualize (Object main view)
+    if( _nodeCanvas.BeginNodeContent(ImGuiExNodeView_Visualise) ){
+
+        _nodeCanvas.EndNodeContent();
+    }
+}
+
+//--------------------------------------------------------------
+void lossyJPEGCompression::drawObjectNodeConfig(){
+    ImGui::Spacing();
+
+    if( ImGui::SliderFloat("JPEG Quality", &this->fJpegQuality, 0.f, 100.f, "%.0f") ){
+        this->setCustomVar(fJpegQuality,"JPEG-quality");
+    }
+
+    ImGuiEx::ObjectInfo(
+                "Encode images in JPEG and read them back (no files, uses a buffer).",
+                "https://mosaic.d3cod3.org/reference.php?r=lossy-jpeg-compression", scaleFactor);
+}
+
+//--------------------------------------------------------------
+void lossyJPEGCompression::removeObjectContent(bool removeFileFromData){
+    // Close threads and mutexes
+    this->stopTurboThread();
+
+    toCompress.close();
+    receiveCompressed.close();
+    waitForThread(true, 1000);
+
+    // Release turboJpeg handles
+    if (handleCompress){
+        tjDestroy(handleCompress);
+    }
+    if (handleDecompress){
+        tjDestroy(handleDecompress);
+    }
+    handleCompress = NULL;
+    handleDecompress = NULL;
+}
+
+// Stops threads
+void lossyJPEGCompression::stopTurboThread(){
+	if( this->isThreadRunning() ){
+		this->stopThread();
+	}
+}
+
+// Starts threads
+void lossyJPEGCompression::startTurboThread(const bool restart){
+	if( !restart){
+		if( !this->isThreadRunning() ){
+			this->startThread();
+		}
+	}
+	else {
+		this->stopTurboThread();
+		//waitForThread();
+
+		this->startThread();
+	}
+
+}
+
+void lossyJPEGCompression::threadedFunction(){
+	// wait until there's a new frame
+	// this blocks the thread, so it doesn't use
+	// the CPU at all, until a frame arrives.
+	// also receive doesn't allocate or make any copies
+	ofPixels pixels;
+
+	while(toCompress.receive(pixels)){
+		this->threadablePixelsFunction(pixels);
+
+		// once processed send the result back to the main thread. in c++11 we can move it to avoid a copy
+		//receiveCompressed.empty();
+#if __cplusplus>=201103
+		receiveCompressed.send(std::move(pixels));
+#else
+		receiveCompressed.send(pixels);
+#endif
+	}
+}
+
+void lossyJPEGCompression::threadablePixelsFunction( ofPixels& pixels){
+	// don't process empty images
+	if(!pixels.isAllocated() || this->handleCompress == NULL || this->handleDecompress == NULL || pixels.getWidth()==0 || pixels.getHeight()==0){
+		return;
+	}
+
+	// COMPRESS IMAGE to JPEG
+	//ofBuffer buffer;
+	int bpp = pixels.getBytesPerPixel();
+	int w = pixels.getWidth();
+	int h = pixels.getHeight();
+	ofBuffer buffer;
+
+	int jpegQuality = ofClamp(this->fJpegQuality, 0,100);
+	//cout << "encoding with Quality = " << jpegQuality << endl;
+
+	int pitch = (w*bpp);
+	int flags = 0;
+	unsigned long size = w*h*bpp;
+
+	int jpegsubsamp = ofNoise(ofGetElapsedTimef()*10.0)*4.0;
+
+	if ( pixels.getImageType() == OF_IMAGE_COLOR_ALPHA){
+		vector<unsigned char> buf; // guaranteed to be destroyed
+		buf.resize(size);
+
+		unsigned char * output = &buf[0];
+		bool compressOK = false;
+
+		try {
+			int result = -1; // tmp
+			result = tjCompress(handleCompress, (unsigned char*)(pixels.getData()), w, pitch, h, bpp, output, &size, jpegsubsamp, jpegQuality, flags);
+
+			if(result==0){
+				buffer.set((const char*)output, size);
+			}
+
+			//std::cout << "TurboJPEG quality=" << jpegQuality << "\t" << jpegsubsamp << "\t" << flags << "\t" << result << "\t" << buf.size() << std::endl;
+			compressOK = (result==0);
+		}
+		catch(std::exception& _e){
+			compressOK = false;
+			// todo: handle error
+		}
+
+		if(compressOK){
+			// DECOMPRESS IMAGE
+			int subsamp;
+			int ok = 0;
+			try {
+				//ok = tjDecompressHeader2(handleDecompress, (unsigned char*)buffer.getData(), buffer.size(), &w, &h, &subsamp);
+				ok = tjDecompressHeader2(handleDecompress, (unsigned char*) output, size, &w, &h, &subsamp);
+			}
+			catch(std::exception& _e){
+				// todo: handle error
+				//std::cout << "lossyJPEGCompression: Error decompressing image..." << std::endl;
+			}
+			//cout << subsamp << endl;
+			if (ok != 0)
+			{
+				printf("Error in tjDecompressHeader2():\n%s\n", tjGetErrorStr());
+				//cout << jpegQuality << "\t" << jpegsubsamp << "\t" << flags << "\t" << " " << endl;
+				return;
+			}
+
+			tjDecompress(handleDecompress, (unsigned char*)buffer.getData(), buffer.size(), pixels.getData(), w, 0, h, bpp, 0);
+
+			// done ! :)
+		}
+		else {
+			std::cout << "Error compressing pixels !" << std::endl;
+		}
+	}
+}
+
+
+OBJECT_REGISTER( lossyJPEGCompression, "lossy JPEG compression", OFXVP_OBJECT_CAT_TEXTURE)
+
+#endif

--- a/src/objects/video/lossyJPEGCompression.h
+++ b/src/objects/video/lossyJPEGCompression.h
@@ -1,0 +1,87 @@
+/*==============================================================================
+
+    ofxVisualProgramming: A visual programming patching environment for OF
+
+    Copyright (c) 2022 Daan de Lange
+
+    ofxVisualProgramming is distributed under the MIT License.
+    This gives everyone the freedoms to use ofxVisualProgramming in any context:
+    commercial or non-commercial, public or private, open or closed source.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+    See https://github.com/d3cod3/ofxVisualProgramming for documentation
+
+==============================================================================*/
+
+// This Object compresses images using the JPEG algorithm
+// Note: Based on code from KarmaMapper : https://github.com/Daandelange/karmaMapper/tree/master/src/effects/lossyImageEffect
+// Note: The threaded stuff needs to be figured out, there's a draft.
+
+#ifndef OFXVP_BUILD_WITH_MINIMAL_OBJECTS
+
+#pragma once
+
+#include "PatchObject.h"
+
+#include "ofxTurboJpeg.h"
+
+class lossyJPEGCompression : public PatchObject, public ofThread {
+
+public:
+
+    lossyJPEGCompression();
+
+    void            newObject() override;
+    void            setupObjectContent(shared_ptr<ofAppGLFWWindow> &mainWindow) override;
+    void            updateObjectContent(map<int,shared_ptr<PatchObject>> &patchObjects) override;
+
+    void            drawObjectContent(ofTrueTypeFont *font, shared_ptr<ofBaseGLRenderer>& glRenderer) override;
+    void            drawObjectNodeGui( ImGuiEx::NodeCanvas& _nodeCanvas ) override;
+    void            drawObjectNodeConfig() override;
+
+    void            removeObjectContent(bool removeFileFromData=false) override;
+
+    void            threadedFunction() override;
+    void            threadablePixelsFunction( ofPixels& pixels);
+    void            stopTurboThread();
+    void            startTurboThread(const bool restart=false);
+
+
+    ofPixels                    *inPixels;
+    ofPixels                    outPixels;
+
+    bool                        bInitialised;
+
+    float fJpegQuality;
+    bool bIsThreaded;
+private:
+    bool bHasNewFrameThreaded;
+
+	ofThreadChannel<ofPixels> toCompress;
+	ofThreadChannel<ofPixels> receiveCompressed;
+
+	tjhandle handleCompress;
+	tjhandle handleDecompress;
+
+    OBJECT_FACTORY_PROPS
+
+};
+
+#endif


### PR DESCRIPTION
Creating this PR to add some comments until it's ready for merging.
(do not merge yet !)

## New objects
- [x] **TextureJpegCompression** : Adds JPEG artefacts to pixels !
- [x] **TextureInformation** : Retrieves texture information.
- [ ] **FaceTracker** : Tracks & detects faces on pixels
- [ ] **UvcController** : (osx only)
- [ ] **VideoGrabberAdvanced** : Advanced webcam object (platform specific implementation)

## Other new stuff:
- **About Mosaic_** : New GPU information section.  _(see sample below)_  
   ````text
   --------------------------------
   GPU Information:
   GL SL 4.1 (programmable)
   Shaders: GLSL 4 (#version 410 core)
   Vendor : NVIDIA Corporation
   GPU : NVIDIA GeForce GTX 760 OpenGL Engine
   OpenGL ver. 4.1 NVIDIA-10.12.65 355.10.05.05b16
   GLSL ver. 4.10 / 410
   GL Extensions (47) :
   GL_ARB_blend_func_extended, GL_ARB_draw_buffers_blend, GL_ARB_draw_indirect, GL_ARB_ES2_compatibility, GL_ARB_explicit_attrib_location, GL_ARB_gpu_shader_fp64, GL_ARB_gpu_shader5, GL_ARB_instanced_arrays, GL_ARB_internalformat_query, GL_ARB_occlusion_query2, GL_ARB_sample_shading, GL_ARB_sampler_objects, GL_ARB_separate_shader_objects, GL_ARB_shader_bit_encoding, GL_ARB_shader_subroutine, GL_ARB_shading_language_include, GL_ARB_tessellation_shader, GL_ARB_texture_buffer_object_rgb32, GL_ARB_texture_cube_map_array, GL_ARB_texture_gather, GL_ARB_texture_query_lod, GL_ARB_texture_rgb10_a2ui, GL_ARB_texture_storage, GL_ARB_texture_swizzle, GL_ARB_timer_query, GL_ARB_transform_feedback2, GL_ARB_transform_feedback3, GL_ARB_vertex_attrib_64bit, GL_ARB_vertex_type_2_10_10_10_rev, GL_ARB_viewport_array, GL_EXT_debug_label, GL_EXT_debug_marker, GL_EXT_depth_bounds_test, GL_EXT_framebuffer_multisample_blit_scaled, GL_EXT_texture_compression_s3tc, GL_EXT_texture_filter_anisotropic, GL_EXT_texture_mirror_clamp, GL_EXT_texture_sRGB_decode, GL_APPLE_client_storage, GL_APPLE_container_object_shareable, GL_APPLE_flush_render, GL_APPLE_object_purgeable, GL_APPLE_rgb_422, GL_APPLE_row_bytes, GL_APPLE_texture_range, GL_ATI_texture_mirror_once, GL_NV_texture_barrier
   ````

## Notes :
- [x] Adds ofxTurboJpeg as a dependency, which also needs some dynamic library fixes. (_only used to load lib turbojpeg, no ofxUvc code is used._)
- [ ] Adds ofxUVC as a dependency (_osx only_)
- [ ] Adds ofxDlib as a dependency (for face detection, comes with big datasets)

## Todo :
- [ ] Test all objects on a multi platform basis :
   - [x] Osx
   - [ ] Linux
   - [ ] Windows
- [ ] Document the new objects
- [ ] Add dependencies to MosaicInstaller